### PR TITLE
Hotfix missing ARANGO_URI env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ LAVA_NODES=[{"host":"lavalink","port":80,"region":"us","password":"password"}]
 # TWITCH_ID=twitch_client_id
 
 #### ArangoDB
-# ARANGO_URI=http://localhost:8529
+ARANGO_URI=http://arango:8529
 # ARANGO_USERNAME=root
 # ARANGO_PASSWORD=supersecret
 # ARANGO_DATABASE=wildbeast


### PR DESCRIPTION
If ARANGO_URI is not defined, Docker defaults to localhost which will not work in a Docker environment.