### PR TITLE
Expand list of known Docker Toolbox issues in docs

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -37,10 +37,10 @@ When done, save the file as **.env**. Then run `#!bash sudo docker-compose up --
 !!! warning
     It is paramount you save the file as **.env**. Do not leave it as **.env.example**, name it **.env.txt** or anything similar. Docker will not recognise it in this case.
 
-![Container list](img/compose-containers.png)
+!!! bug "Known docker-compose issues"
+    On certain systems or setups Docker may refuse to run commands properly without **sudo** and will throw cryptic errors as a result. Try running the command with **sudo** before consulting help and also check your system process control to see if Docker is running.
 
-!!! bug "Weird Docker errors"
-    On certain systems Docker may refuse to run commands properly without **sudo** and will throw cryptic errors as a result. Try running the command with **sudo** before consulting help and also check your system process control to see if Docker is running.
+![Container list](img/compose-containers.png)
 
 ### Initialising
 

--- a/docs/install_windows.md
+++ b/docs/install_windows.md
@@ -59,10 +59,15 @@ When done, save the file as **.env**. Then run `#!bash docker-compose up --no-st
 !!! warning
     It is paramount you save the file as **.env**. Do not leave it as **.env.example**, name it **.env.txt** or anything similar. Docker will not recognise it in this case.
 
-![Container list](img/kitematic-containers.png)
+!!! bug "Known docker-compose issues"
+    Docker Toolbox does not start automatically with Windows out of the box - it needs to be started explicitly. Thus, if you do not perform this step, you may run into cryptic errors when attempting to compose. These errors are known to arise:
 
-!!! bug "Couldn't connect to Docker daemon"
-    Users running Docker Toolbox may need to start the Docker daemon explicitly in order for Compose to work. Docker Toolbox should create a desktop icon called **Docker Quickstart Terminal** upon installation. Start it, switch back to the previous terminal window and run the compose command again.
+    **Could not connect to Docker daemon**<br>
+    **Windows named pipe error: The system cannot find the file specified**
+
+    Docker Toolbox should create a desktop icon called **Docker Quickstart Terminal** upon installation. Start it, wait for it to completely start (Until it shows **Start interactive shell**), restart your terminal and run the compose command again.
+
+![Container list](img/kitematic-containers.png)
 
 ### Initialising
 


### PR DESCRIPTION
Added a mention of what common errors docker-compose may throw on Windows if the Docker daemon is not properly started beforehand, namely `Could not connect to Docker daemon` and `Windows named pipe error: The system cannot find the file specified`, and how to fix them.

This issue only affects Docker Toolbox and thus Windows 10 Home users. Users using normal Docker are unaffected as that program is registered as a startup service, but this is still important to mention as it seems to be a recurring issue among our DT userbase.