### PR TITLE
Proposal: Replace local build with volume-based system

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ services:
   wildbeast:
     image: dougley/wildbeast
     volumes:
-      - .:/opt/wildbeast
+      - ./src:/opt/wildbeast/src
+      - ./index.js:/opt/wildbeast/index.js
     env_file:
       - .env
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: '3'
 services:
   wildbeast:
-    build: .
+    image: dougley/wildbeast
+    volumes:
+      - .:/opt/wildbeast
     env_file:
       - .env
     links:

--- a/docs/decoupling.md
+++ b/docs/decoupling.md
@@ -3,15 +3,17 @@ description: Instructions on running WildBeast from source instead of from Docke
 path: tree/master/docs
 source: decoupling.md
 
-This document outlines the procedure for decoupling WildBeast from Docker and running it from source instead, enabling custom commands and other modifications to the behaviour of it.
+This document outlines the procedure for decoupling WildBeast from Docker, allowing the entire system to be leveraged as opposed to a Docker sandbox.
 
 ## Preface
 
-If you have already set up your WildBeast instance in accordance with the available installation guides, feel free to jump to the next section. If you have not done this yet, however, please follow through with that procedure before embarking onto this guide. Most of the steps assume knowledge of what has been done previously, and as such it is highly recommended to follow proper procedure first.
+If you have already set up your WildBeast instance in accordance with the available installation guides, feel free to jump to the next section. If you have not done this yet, however, please follow through with that procedure before embarking onto this guide.
 
-Additionally, be sure to shutdown all existing Docker containers pertaining to WildBeast before proceeding.
+Additionally, consider whether you need to go through the decoupling process to begin with. The Docker container for WildBeast runs the code that is in the WildBeast install directory, and when the container is restarted, the changes are mirrored. However, if you want to use something akin to live reloading (Such as Nodemon) or have other valid reasons, feel free to proceed.
 
 ## Reconfiguring containers and WildBeast
+
+Shutdown all existing Docker containers pertaining to WildBeast before starting.
 
 !!! warning "Port conflicts"
     If you have other services running on ports **8529**, **80** or **2333**, select other available ports in the sections below and update your configuration accordingly. This is to avoid port conflicts. However, **do not modify the Docker port** in contradiction to this guide, or you will have trouble reaching the containers in the desired manner.

--- a/docs/decoupling.md
+++ b/docs/decoupling.md
@@ -9,7 +9,7 @@ This document outlines the procedure for decoupling WildBeast from Docker, allow
 
 If you have already set up your WildBeast instance in accordance with the available installation guides, feel free to jump to the next section. If you have not done this yet, however, please follow through with that procedure before embarking onto this guide.
 
-Additionally, consider whether you need to go through the decoupling process to begin with. The Docker container for WildBeast runs the code that is in the WildBeast install directory, and when the container is restarted, the changes are mirrored. However, if you want to use something akin to live reloading (Such as Nodemon) or have other valid reasons, feel free to proceed.
+Additionally, consider whether you need to go through the decoupling process to begin with. The Docker container for WildBeast runs the code that is in the WildBeast directory, and when the container is restarted, the changes are mirrored. However, if you want to use something akin to live reloading (Such as Nodemon) or have other valid reasons, feel free to proceed.
 
 ## Reconfiguring containers and WildBeast
 

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -111,6 +111,14 @@ If your output resembles the following, your bot is all set.
 
 You can test the bot by running the **ping** command (With your prefix) in a text channel that the bot can see. If it answers "Pong!", then your bot is set up.
 
+## Making changes
+
+If you feel up for some tinkering, you're free to make modifications to the source code. When you have made your changes and want to deploy them, simply restart the **wildbeast_wildbeast_1** container with the command `#!bash sudo docker restart wildbeast_wildbeast_1`. The changes you made will then be reflected in the public facing bot.
+
+**Note:** You make changes to the source code at your own risk and responsibility. Support will not be provided for issues that stem from modifying the source code improperly. In other words, issues that are not our responsibility cannot be remedied by us either.
+
+## Closing words
+
 If you have further questions or need help with something, we'd be happy to help. You can find a link to the official server below.
 
 **Enjoy your bot and have fun!**

--- a/docs/install_windows.md
+++ b/docs/install_windows.md
@@ -116,6 +116,14 @@ Your WildBeast instance should now be good to go. Start both the **wildbeast_ara
 
 You can test the bot by running the **ping** command (With your prefix) in a text channel that the bot can see. If it answers "Pong!", then your bot is set up.
 
+## Making changes
+
+If you feel up for some tinkering, you're free to make modifications to the source code. When you have made your changes and want to deploy them, simply restart the **wildbeast_wildbeast_1** container in Kitematic. The changes you made will then be reflected in the public facing bot.
+
+**Note:** You make changes to the source code at your own risk and responsibility. Support will not be provided for issues that stem from modifying the source code improperly. In other words, issues that are not our responsibility cannot be remedied by us either.
+
+## Closing words
+
 If you have further questions or need help with something, we'd be happy to help. You can find a link to the official server below.
 
 **Enjoy your bot and have fun!**

--- a/docs/minimal_setup.md
+++ b/docs/minimal_setup.md
@@ -10,7 +10,7 @@ This document outlines the procedure for running WildBeast with as few external 
 This way of running WildBeast is intended for a very specific niche, and the program makes compromises to fill that niche. If only possible, it's preferable to use the Docker-based setup procedure instead as the gains are notable. See other documentation in this category if that is what you seek.
 
 !!! note
-    **This procedure will not enable you to run WildBeast with zero external dependencies** - FFMPEG still has to be installed separately for audio encoding. You can, however, omit installing FFMPEG and set the **WILDBEAST_DISABLE_MUSIC** environment variable to **1**. This will limit the bot's functionality, but also requires no additional dependency setup.
+    **This procedure will not allow you to run WildBeast with zero external dependencies** - FFMPEG still has to be installed separately for audio encoding. You can, however, omit installing FFMPEG and set the **WILDBEAST_DISABLE_MUSIC** environment variable to **1**. This will limit the bot's functionality, but also requires no additional dependency setup.
 
 Installing in this way has the following caveats:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ edit_uri: edit/master/docs/
 
 copyright: 'Copyright © 2016-2018 TheSharks. "Discord", "Discord App", and any associated logos are registered trademarks of Hammer & Chisel, inc.'
 
-pages:
+nav:
   - Home: 'index.md'
   - Migrating v4 => v6: migrating.md
   - Commands:


### PR DESCRIPTION
This proposed change replaces the on-demand builds introduced in 97198dc with a volume-based system. Local builds take considerably longer to perform and are more cumbersome for end users - not to mention they would make an entire step in our CI workflow, publishing the main image to Docker Hub, pointless. The new docker-compose configuration mounts the WildBeast install directory to the main container (**wildbeast_wildbeast_1**). As a result, changes made to the source code will be reflected in the Docker container immediately (WYSIWYG behaviour) and are available on the public facing side of the bot after a process restart.

This should in my opinion, however, not replace the decoupling process. There are still cases where the decoupling process can be useful, such as when live reloading with programs like Nodemon is warranted - something this volume setup has no answer for. I suggest that the decoupling guide is kept in place as an alternative running mode as a result of this.

In addition, to reflect this change, the decoupling guide has been updated with a notice to reconsider if the process is necessary for the purposes of the reader, in light of already being able to make changes as a result of the volume setup.