### PR TITLE
Change YT service from Lavalink to Invidious

### DIFF
--- a/src/classes/VoiceConnection.js
+++ b/src/classes/VoiceConnection.js
@@ -67,6 +67,11 @@ module.exports = class VoiceConnection {
   async resolve (ctx) {
     ctx = ctx.trim()
     const ytreg = /(?:https?:\/\/)?(?:www\.)?youtu(?:.be\/|be\.com\/watch\?v=)(\w{11})/
+    const authorImg = (data) => {
+      if (!data.authorThumbnails[0].url || data.authorThumbnails[0].url.length < 1) return undefined // this can happen sometimes
+      else if (!data.authorThumbnails[0].url.startsWith('https:')) return `https:${data.authorThumbnails[0].url}`
+      return data.authorThumbnails[0].url
+    }
     if (ytreg.test(ctx) && process.env.INVIDIOUS_HOST) {
       const videoid = ctx.match(ytreg)[1]
       const SA = require('superagent')
@@ -78,7 +83,7 @@ module.exports = class VoiceConnection {
         title: resp.body.title,
         uri: `https://youtu.be/${videoid}`,
         image: `https://i.ytimg.com/vi/${videoid}/hqdefault.jpg`,
-        authorImage: (resp.body.authorThumbnails[0].url.startsWith('https:')) ? resp.body.authorThumbnails[0].url : `https:${resp.body.authorThumbnails[0].url}`,
+        authorImage: authorImg(resp.body),
         authorURL: `https://youtube.com${resp.body.authorUrl}`
       }
       return lavaresp

--- a/src/classes/VoiceConnection.js
+++ b/src/classes/VoiceConnection.js
@@ -69,7 +69,7 @@ module.exports = class VoiceConnection {
     ctx = ctx.trim()
     try {
       const url = new URL(ctx)
-      if (/(?:https?:\/\/)?(?:www\.)?youtu(.be|be\.com)/.test(url.hostname)) {
+      if (process.env.INVIDIOUS_HOST && /(?:https?:\/\/)?(?:www\.)?youtu(.be|be\.com)/.test(url.hostname)) {
         if (url.hostname === 'youtu.be') return this._invidiousResolve(url.pathname.slice(1))
         if (url.searchParams.has('list')) return this._invidiousPlaylist(url.searchParams.get('list'))
         if (url.searchParams.has('v')) return this._invidiousResolve(url.searchParams.get('v'))
@@ -115,7 +115,7 @@ module.exports = class VoiceConnection {
     const SA = require('superagent')
     const info = await SA.get(`${process.env.INVIDIOUS_HOST}/api/v1/videos/${videoId}?fields=author,title,authorThumbnails,authorUrl,adaptiveFormats`)
     const tag = info.body.adaptiveFormats.find(x => itags.includes(x.itag))
-    const lavaresp = await this._encoder.node.loadTracks(`${process.env.INVIDIOUS_HOST}/latest_version?id=${videoId}&itag=${tag.itag}&local=true`)
+    const lavaresp = await this._encoder.node.loadTracks(`${process.env.INVIDIOUS_HOST}/latest_version?id=${videoId}&itag=${tag.itag}${process.env.INVIDIOUS_PROXY ? '&local=true' : ''}`)
     if (lavaresp.loadType !== 'TRACK_LOADED') return lavaresp
     lavaresp.tracks[0].info = {
       ...lavaresp.tracks[0].info,

--- a/src/commands/music/play.js
+++ b/src/commands/music/play.js
@@ -14,6 +14,23 @@ module.exports = new Command(async function (msg, suffix) {
             return m.edit(`Playlist ${x.playlistInfo.name} has been added`)
           } else return m.edit('Nothing found with your search query')
         }
+        case 'IV_PLAYLIST_LOADED': {
+          return m.edit({
+            content: 'Your playlist has finished loading',
+            embed: {
+              url: x.uri,
+              title: x.title,
+              author: {
+                name: x.author,
+                icon_url: x.authorImage,
+                url: x.authorURL
+              },
+              thumbnail: {
+                url: x.image
+              }
+            }
+          })
+        }
         case 'SEARCH_RESULT':
         case 'TRACK_LOADED': {
           if (x.tracks && x.tracks.length > 0) {

--- a/src/commands/music/play.js
+++ b/src/commands/music/play.js
@@ -30,7 +30,7 @@ module.exports = new Command(async function (msg, suffix) {
       }
     } else return this.safeSendMessage(msg.channel, "I'm not streaming in this server")
   } catch (e) {
-    logger.error(e)
+    logger.error('CMD', e)
     if (!(m instanceof require('eris').Messsage)) await this.safeSendMessage(msg.channel, 'Something went wrong, try again?')
     else await m.edit('Something went wrong, try again?')
   }

--- a/src/commands/music/play.js
+++ b/src/commands/music/play.js
@@ -1,11 +1,11 @@
 const Command = require('../../classes/Command')
 
 module.exports = new Command(async function (msg, suffix) {
-  const m = await this.safeSendMessage(msg.channel, 'Working on it...')
-  try {
-    const client = require('../../components/client')
-    const player = client.voiceConnectionManager.get(msg.channel.guild.id)
-    if (player) {
+  const client = require('../../components/client')
+  const player = client.voiceConnectionManager.get(msg.channel.guild.id)
+  if (player) {
+    const m = await this.safeSendMessage(msg.channel, 'Working on it...')
+    try {
       const x = await player.resolve(suffix)
       switch (x.loadType) {
         case 'PLAYLIST_LOADED': {
@@ -45,12 +45,12 @@ module.exports = new Command(async function (msg, suffix) {
         case 'NO_MATCHES': return m.edit('Nothing found with your search query')
         default: return m.edit('Something went wrong while adding this track, try again later')
       }
-    } else return this.safeSendMessage(msg.channel, "I'm not streaming in this server")
-  } catch (e) {
-    logger.error('CMD', e)
-    if (!(m instanceof require('eris').Message)) await this.safeSendMessage(msg.channel, 'Something went wrong, try again?')
-    else await m.edit('Something went wrong, try again?')
-  }
+    } catch (e) {
+      logger.error('CMD', e)
+      if (!(m instanceof require('eris').Message)) await this.safeSendMessage(msg.channel, 'Something went wrong, try again?')
+      else await m.edit('Something went wrong, try again?')
+    }
+  } else return this.safeSendMessage(msg.channel, "I'm not streaming in this server")
 }, {
   aliases: ['request'],
   prereqs: ['musicCommand'],

--- a/src/commands/music/play.js
+++ b/src/commands/music/play.js
@@ -31,7 +31,7 @@ module.exports = new Command(async function (msg, suffix) {
     } else return this.safeSendMessage(msg.channel, "I'm not streaming in this server")
   } catch (e) {
     logger.error('CMD', e)
-    if (!(m instanceof require('eris').Messsage)) await this.safeSendMessage(msg.channel, 'Something went wrong, try again?')
+    if (!(m instanceof require('eris').Message)) await this.safeSendMessage(msg.channel, 'Something went wrong, try again?')
     else await m.edit('Something went wrong, try again?')
   }
 }, {

--- a/src/commands/music/play.js
+++ b/src/commands/music/play.js
@@ -1,33 +1,39 @@
 const Command = require('../../classes/Command')
 
 module.exports = new Command(async function (msg, suffix) {
-  const client = require('../../components/client')
-  const player = client.voiceConnectionManager.get(msg.channel.guild.id)
-  if (player) {
-    const m = await this.safeSendMessage(msg.channel, 'Working on it...')
-    const x = await player.resolve(suffix)
-    switch (x.loadType) {
-      case 'PLAYLIST_LOADED': {
-        if (x.tracks && x.tracks.length > 0) {
-          player.addMany(x.tracks)
-          return m.edit(`Playlist ${x.playlistInfo.name} has been added`)
-        } else return m.edit('Nothing found with your search query')
+  const m = await this.safeSendMessage(msg.channel, 'Working on it...')
+  try {
+    const client = require('../../components/client')
+    const player = client.voiceConnectionManager.get(msg.channel.guild.id)
+    if (player) {
+      const x = await player.resolve(suffix)
+      switch (x.loadType) {
+        case 'PLAYLIST_LOADED': {
+          if (x.tracks && x.tracks.length > 0) {
+            player.addMany(x.tracks)
+            return m.edit(`Playlist ${x.playlistInfo.name} has been added`)
+          } else return m.edit('Nothing found with your search query')
+        }
+        case 'SEARCH_RESULT':
+        case 'TRACK_LOADED': {
+          if (x.tracks && x.tracks.length > 0) {
+            player.add(x.tracks[0])
+            return m.edit('Your track has been added')
+          } else return m.edit('Nothing found with your search query')
+        }
+        case 'LOAD_FAILED': {
+          if (x.exception.severity === 'COMMON') return m.edit(`I'm unable to play that track: \`${x.exception.message}\``)
+          else return m.edit("I'm unable to play that track for unknown reasons")
+        }
+        case 'NO_MATCHES': return m.edit('Nothing found with your search query')
+        default: return m.edit('Something went wrong while adding this track, try again later')
       }
-      case 'SEARCH_RESULT':
-      case 'TRACK_LOADED': {
-        if (x.tracks && x.tracks.length > 0) {
-          player.add(x.tracks[0])
-          return m.edit('Your track has been added')
-        } else return m.edit('Nothing found with your search query')
-      }
-      case 'LOAD_FAILED': {
-        if (x.exception.severity === 'COMMON') return m.edit(`I'm unable to play that track: \`${x.exception.message}\``)
-        else return m.edit("I'm unable to play that track for unknown reasons")
-      }
-      case 'NO_MATCHES': return m.edit('Nothing found with your search query')
-      default: return m.edit('Something went wrong while adding this track, try again later')
-    }
-  } else return this.safeSendMessage(msg.channel, "I'm not streaming in this server")
+    } else return this.safeSendMessage(msg.channel, "I'm not streaming in this server")
+  } catch (e) {
+    logger.error(e)
+    if (!(m instanceof require('eris').Messsage)) await this.safeSendMessage(msg.channel, 'Something went wrong, try again?')
+    else await m.edit('Something went wrong, try again?')
+  }
 }, {
   aliases: ['request'],
   prereqs: ['musicCommand'],

--- a/src/commands/music/queue.js
+++ b/src/commands/music/queue.js
@@ -23,7 +23,7 @@ const createEmbed = (ctx) => {
       fields: ctx.slice(0, 10).map(x => {
         return {
           name: ctx.indexOf(x) + 1,
-          value: `${x.info.title} - ${x.info.author}`
+          value: `[${x.info.title} - ${x.info.author}](${x.info.uri})`
         }
       })
     }


### PR DESCRIPTION
# Please check the following boxes
> All boxes are required

- [x] I agree to the [Contribution Guidelines](https://github.com/TheSharks/WildBeast/blob/master/.github/CONTRIBUTING.md) and to the [Code of Conduct](https://github.com/TheSharks/WildBeast/blob/master/.github/CODE_OF_CONDUCT.md)
- [x] I tested my code and I verified it's working to the best of my ability

# Describe your pull request

Support Youtube video's via the Invidious API

**Why is this change needed?**

Direct Lavalink resolving for Youtube introduces extra hurdles, like Lavalink not having great options to circumnavigate Youtube limitations aside from support for IP-rotation. Invidious is a libre alternative frontend for Youtube and features a comprehensive developer API, from testing Invidious vastly increased success rate for Lavalink while not/minimally harming quality or compatibility. The only thing that doesn't work reliably at this time are livestreams, possibly due to a Lavalink bug ([logs](https://gist.github.com/Dougley/53c4ac16658711d8004be68aaaf51267))

**Does your pull request solve an open issue? If yes, please mention what one**

Not applicable
